### PR TITLE
fix: container delete will no longer throw 500 error if container is …

### DIFF
--- a/src/AppBundle/Controller/ContainerController.php
+++ b/src/AppBundle/Controller/ContainerController.php
@@ -696,8 +696,6 @@ class ContainerController extends Controller
     public function deleteAction($containerId, EntityManagerInterface $em, ContainerApi $api, ContainerStateApi $stateApi)
     {
         $container = $this->getDoctrine()->getRepository(Container::class)->find($containerId);
-        $profiles = $container->getProfiles();
-
 
         if (!$container) {
             throw new ElementNotFoundException(


### PR DESCRIPTION
…not in db.